### PR TITLE
#1 OpenXE does not run on Windows

### DIFF
--- a/classes/Core/Installer/Psr4ClassNameResolver.php
+++ b/classes/Core/Installer/Psr4ClassNameResolver.php
@@ -35,7 +35,7 @@ final class Psr4ClassNameResolver
     {
         // Normalize inputs
         $prefix = trim($prefix, '\\') . '\\';
-        $baseDir = rtrim($baseDir, '/') . '/';
+        $baseDir = rtrim($baseDir, '/\\') . DIRECTORY_SEPARATOR;
 
         $this->prefixes[$prefix] = $baseDir;
     }


### PR DESCRIPTION
Fixed directory separator usage for dependency injection class map.